### PR TITLE
Fix main module DataType export

### DIFF
--- a/lib/api-first-spec.js
+++ b/lib/api-first-spec.js
@@ -1,5 +1,5 @@
 "use strict";
-var 
+var
   extend = require("extend"),
   util = require("util"),
   assert = require("chai").assert,
@@ -24,7 +24,7 @@ var Constants = {
     URLENCODED: "application/x-www-form-urlencoded",
     MULTIPART: "multipart/form-data"
   },
-  DataType: Param.DataType
+  DataType: DataType
 };
 
 function API(config) {
@@ -115,7 +115,7 @@ function API(config) {
     }
     function testRulesReference(param, rules) {
       it("Validate rules reference.", function() {
-        var 
+        var
           pool = new ParamPool(param),
           ret = [];
         Object.keys(rules).forEach(function(key) {
@@ -158,7 +158,7 @@ function API(config) {
       assert.equal("API", api.constructor.name, "login must be API object.");
     }
     function testUnknownKeys() {
-      var 
+      var
         keys = [
           "name",
           "description",
@@ -173,7 +173,7 @@ function API(config) {
           "isNotFound",
           "isUnauthorized",
           "isClientError",
-        ], 
+        ],
         ret = [];
       Object.keys(config).forEach(function(key) {
         if (keys.indexOf(key) === -1) {


### PR DESCRIPTION
The Param module doesn't actually export `DataType`, so the exported `DataType` is always `undefined`. Since the main module already imports `DataType`, simply exporting that fixes the issue.