### PR TITLE
Default static parameter for http client

### DIFF
--- a/lib/api-first-spec.js
+++ b/lib/api-first-spec.js
@@ -234,8 +234,8 @@ module.exports = extend({
   define: function(config) {
     return new API(config);
   },
-  host: function(host, ssl) {
-    return new HttpClient(host, ssl);
+  host: function(host, ssl, defaults) {
+    return new HttpClient(host, ssl, defaults);
   },
   skipTest: function(v) {
     if (typeof(v) === "boolean") {

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -262,7 +262,7 @@ function HttpClient(host, ssl, defaults) {
     req.end();
   }
   function copy() {
-    var ret = new HttpClient(host + ":" + port, ssl);
+    var ret = new HttpClient(host + ":" + port, ssl, defaults);
     ret.assign(cookie, api, params, headers);
     return ret;
   }

--- a/lib/httpClient.js
+++ b/lib/httpClient.js
@@ -6,7 +6,18 @@ var
   util = require("util"),
   assert = require("chai").assert;
 
-function HttpClient(host, ssl) {
+
+/**
+ * Generates http client; wrapper of http/https library.
+ *
+ * `defaults` expect have two keys: params and headers
+ *
+ * @param {string} host
+ * @param {boolean} ssl use to switch using `https` and `http`
+ * @param {object} defaults will set unmodifiable default value
+ * @return {object}
+ */
+function HttpClient(host, ssl, defaults) {
   function buildCookie(cookie) {
     var ret = cookie;
     if (typeof(cookie) === "object") {
@@ -172,8 +183,8 @@ function HttpClient(host, ssl) {
     }
     var 
       currentApi = api,
-      currentParams = extend({}, params),
-      currentHeaders = extend({}, headers);
+      currentParams = extend({}, defaults.params, params),
+      currentHeaders = extend({}, defaults.headers, headers);
     params = null;
     headers = null;
     if (!currentApi) {
@@ -269,6 +280,12 @@ function HttpClient(host, ssl) {
     api = null,
     params = null,
     headers = null;
+
+  // Initialize default parameter object
+  defaults = defaults || {};
+  defaults.params = defaults.params || {};
+  defaults.headers = defaults.headers || {};
+
   if (host.indexOf(":") != -1) {
     port = parseInt(host.split(":")[1], 10);
     host = host.split(":")[0];

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-contrib-watch": "^0.6.1",
     "load-grunt-tasks": "^3.1.0",
+    "mocha": "^3.4.1",
     "pg": "^4.3.0",
     "sql-fixtures": "^0.9.0",
     "time-grunt": "^1.0.0"


### PR DESCRIPTION
Sometimes, there are headers that want always to be set, such as
"X-Requested-With"; used for CSRF proof for RESTful API

Currently, options set by `withHeaders` method is been reset every time and have to set
`withHeaders` each time sending request. By this commit, user can set
static parameter that won't be reset by each request.